### PR TITLE
a few fixes to get the TUI working on non-RPi systems also

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dip-coater"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     {name="Rik Huygen", email="rik.huygen@kuleuven.be"},
     {name="Sibo Van Gool", email="sibo.vangool@kuleuven.be"}
@@ -23,14 +23,13 @@ requires-python = ">=3.8, <4.0"
 dependencies = [
     "textual",
     "textual-dev",
-    "TMC-2209-Raspberry-Pi"
 ]
 
 [project.urls]
 repository = "https://github.com/IvS-KULeuven/dip_coater"
 
 [project.optional-dependencies]
-rpi = ["RPi.GPIO"]
+rpi = ["RPi.GPIO", "TMC-2209-Raspberry-Pi"]
 
 [project.scripts]
 dip-coater = "dip_coater.tui:main"

--- a/src/MyTMC_2209/TMC_2209_StepperDriver.py
+++ b/src/MyTMC_2209/TMC_2209_StepperDriver.py
@@ -8,10 +8,13 @@ class TMC_2209:
                  driver_address=0, gpio_mode=None, loglevel=None, skip_uart_init=False):
         self.tmc_logger = TMC_logger(loglevel, f"TMC2209 {driver_address}")
 
-    def set_stepmode(self, ):
+    def set_stepmode(self, _stepmode: int):
         pass
 
     def set_motor_enabled(self, en):
+        pass
+
+    def set_vactual(self, flag: bool):
         pass
 
     def set_vactual_rps(self, rps, duration=0, revolutions=0, acceleration=0):

--- a/src/dip_coater/tui.py
+++ b/src/dip_coater/tui.py
@@ -32,16 +32,16 @@ except ModuleNotFoundError:
     import sys
     import MyRPi
     sys.modules["RPi"] = MyRPi
+
 try:
     import TMC_2209
 except ModuleNotFoundError:
     import sys
-    import MyTMC_2209
-    sys.modules["TMC_2209"] = MyTMC_2209
+    import MyTMC_2209 as TMC_2209
+    sys.modules["TMC_2209"] = TMC_2209
 
 from TMC_2209._TMC_2209_logger import Loglevel
-import dip_coater.motor as motor
-from motor import TMC2209_MotorDriver
+from dip_coater.motor import TMC2209_MotorDriver
 
 # Logging settings
 STEP_MODE_WRITE_TO_LOG = False


### PR DESCRIPTION
This sets the dependency for "TMC-2209-Raspberry-Pi" in optional dependencies, otherwise the project can not be installed on a non-RP system.

Fixes a missing method in the mock library.