### PR TITLE
Fix some motor config & ensure version 0.4.3 of driver lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,29 @@
 
 This small App is developed for IvS to drive the motor for the dip coater. The motor is connected to a Raspberry Pi through the GPIO bus.
 
-This App is develop with [Textual](https://www.textualize.io).
+This App is developed with [Textual](https://www.textualize.io).
 
 ## Installation
 
 Always install in a dedicated virtual environment!
 
+```bash
+$ cd </path/to/dip-coater>
+$ python3 -m venv venv --prompt=dip-coater
+$ source venv/bin/activate
+$ pip install --upgrade pip setuptools wheel
+$ pip install -e .
+```
+
 On a Raspberry Pi, install the project together with the RPi package:
 
-```
+```bash
 $ pip install dip-coater[rpi] 
 ```
 
 When you want to develop and test on a macOS or Linux system, install without the RPi package. The App will mock the imports and functions.
 
-```
+```bash
 $ pip install dip-coater
 ```
 
@@ -24,7 +32,7 @@ $ pip install dip-coater
 
 Start the App from the command line in a terminal. You can start it also from a remote ssh session in a terminal, e.g. if you have the installation on the Raspberry Pi and you have a remote connection to your RPi.
 
-```
+```bash
 $ dip-coater
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.8, <4.0"
 dependencies = [
     "textual",
     "textual-dev",
-    "TMC-2209-Raspberry-Pi"
+    "TMC-2209-Raspberry-Pi>=0.4.3"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dip-coater"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     {name="Rik Huygen", email="rik.huygen@kuleuven.be"},
     {name="Sibo Van Gool", email="sibo.vangool@kuleuven.be"}

--- a/src/dip_coater/motor.py
+++ b/src/dip_coater/motor.py
@@ -27,11 +27,13 @@ class TMC2209_MotorDriver:
         # Set motor driver settings
         self.tmc.set_vactual(True)      # Motor is controlled by UART
         self.tmc.set_direction_reg(False)
-        self.tmc.set_current(1500)
+        self.tmc.set_current(1500, pdn_disable=True)    # mA (also disable PDN, otherwise UART can't be used)
         self.tmc.set_interpolation(True)
         self.tmc.set_spreadcycle(False)  # True: spreadcycle, False: stealthchop
         self.tmc.set_microstepping_resolution(_stepmode)  # 1, 2, 4, 8, 16, 32, 64, 128, 256
         self.tmc.set_internal_rsense(False)
+
+        self.tmc.set_movement_abs_rel(MovementAbsRel.ABSOLUTE)
 
     def set_stepmode(self, _stepmode=4):
         """ Set the step mode of the motor driver


### PR DESCRIPTION
This PR fixes some motor driver configs + requires version 0.4.3 or greater of the motor driver lib, since earlier versions contain a bug that causes stepmode changes to not update properly (see https://github.com/Chr157i4n/TMC2209_Raspberry_Pi/issues/49).