### PR TITLE
Add coder for custom control routine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,7 @@ classifiers = [
 requires-python = ">=3.8, <4.0"
 
 dependencies = [
-    "textual",
-    "textual[syntax]",
+    "textual>=0.48.0",
     "textual-dev",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dip-coater"
-version = "0.10.0"
+version = "0.11.0"
 authors = [
     {name="Rik Huygen", email="rik.huygen@kuleuven.be"},
     {name="Sibo Van Gool", email="sibo.vangool@kuleuven.be"}
@@ -22,6 +22,7 @@ requires-python = ">=3.8, <4.0"
 
 dependencies = [
     "textual",
+    "textual[syntax]",
     "textual-dev",
 ]
 

--- a/src/dip_coater/code_editor_init_content.py
+++ b/src/dip_coater/code_editor_init_content.py
@@ -1,21 +1,7 @@
-""" Coder API:
-
-self.enable_motor()         # Arm the motor
-self.disable_motor()        # Disarm the motor
-
-self.move_down(10, 5)       # Move the coater down by 10 mm at 5 mm/s
-self.move_down(10, 5, 10)   # Move the coater down by 10 mm at 5 mm/s and 10 mm/s^2 acceleration
-
-self.move_up(10, 5)         # Move the coater up by 10 mm at 5 mm/s
-self.move_up(10, 5, 10)     # Move the coater up by 10 mm at 5 mm/s and 10 mm/s^2 acceleration
-
-self.sleep(5)               # Sleep for 5 seconds
-
+"""
 !!! USE THIS EDITOR WITH CAUTION !!!
 Stick to the provided API and do not import any modules or use any functions that are not part of the API.
 """
-
-self.enable_motor()
 
 # ====== PARAMETERS ======
 distance_down = 10  # mm
@@ -26,13 +12,16 @@ speed_up = 2        # mm/s
 
 wait_time = 5       # s
 
-# ====== MOVE UP ======
+# ====== CODE ======
+self.enable_motor()
+
+# == MOVE UP ==
 self.move_down(distance_down, speed_down)
 
-# ====== WAIT ======
+# == WAIT ==
 self.sleep(wait_time)
 
-# ====== MOVE DOWN ======
+# == MOVE DOWN ==
 self.move_up(distance_up, speed_up)
 
 self.disable_motor()

--- a/src/dip_coater/code_editor_init_content.py
+++ b/src/dip_coater/code_editor_init_content.py
@@ -1,0 +1,38 @@
+""" Coder API:
+
+self.enable_motor()         # Arm the motor
+self.disable_motor()        # Disarm the motor
+
+self.move_down(10, 5)       # Move the coater down by 10 mm at 5 mm/s
+self.move_down(10, 5, 10)   # Move the coater down by 10 mm at 5 mm/s and 10 mm/s^2 acceleration
+
+self.move_up(10, 5)         # Move the coater up by 10 mm at 5 mm/s
+self.move_up(10, 5, 10)     # Move the coater up by 10 mm at 5 mm/s and 10 mm/s^2 acceleration
+
+self.sleep(5)               # Sleep for 5 seconds
+
+!!! USE THIS EDITOR WITH CAUTION !!!
+Stick to the provided API and do not import any modules or use any functions that are not part of the API.
+"""
+
+self.enable_motor()
+
+# ====== PARAMETERS ======
+distance_down = 10  # mm
+distance_up = 10    # mm
+
+speed_down = 5      # mm/s
+speed_up = 2        # mm/s
+
+wait_time = 5       # s
+
+# ====== MOVE UP ======
+self.move_down(distance_down, speed_down)
+
+# ====== WAIT ======
+self.sleep(wait_time)
+
+# ====== MOVE DOWN ======
+self.move_up(distance_up, speed_up)
+
+self.disable_motor()

--- a/src/dip_coater/coder_API.md
+++ b/src/dip_coater/coder_API.md
@@ -1,0 +1,18 @@
+```python
+self.enable_motor()         # Arm the motor
+self.disable_motor()        # Disarm the motor
+
+# Move the motor down by distance_mm at speed_mm_s speed and (optional) acceleration_mm_s acceleration
+self.move_down(distance_mm, speed_mm_s, acceleration_mm_s2=None)
+### Examples:
+self.move_down(10, 5)       # Move the coater down by 10 mm at 5 mm/s
+self.move_down(10, 5, 10)   # Move the coater down by 10 mm at 5 mm/s and 10 mm/s^2 acceleration
+
+# Move the motor up by distance_mm at <speed_mm_s> speed and (optional) <acceleration_mm_s> acceleration
+self.move_down(distance_mm, speed_mm_s, acceleration_mm_s2=None)
+### Examples:
+self.move_up(10, 5)         # Move the coater up by 10 mm at 5 mm/s
+self.move_up(10, 5, 10)     # Move the coater up by 10 mm at 5 mm/s and 10 mm/s^2 acceleration
+
+self.sleep(5)               # Sleep for 5 seconds
+```

--- a/src/dip_coater/help.md
+++ b/src/dip_coater/help.md
@@ -23,3 +23,39 @@ To access more advanced control settings, you can switch to the `Advanced` tab o
 Authors: Rik Huygen (https://github.com/rhuygen), Sibo Van Gool (https://github.com/SiboVG)
 
 Press ESCAPE to Exit.
+
+## Coder API
+
+You can create custom control routines using the coder in the `Coder` tab. To do so, you must write Python code with the following
+functions (the so-called 'Coder API'):
+- `self.enable_motor()`: arm the motor
+- `self.disable_motor()`: disarm the motor
+- `self.move_down(distance_mm, speed_mm_s, acceleration_mm_s=None)`: move the motor down by supplying the following parameters:
+  - `distance_mm`: the distance in mm to move down
+  - `speed_mm_s`: the speed in mm/s to move down
+  - `acceleration_mm_s`: the acceleration in mm/s^2 to move down (optional, leave empty for default acceleration)
+- `self.move_up(distance_mm, speed_mm_s, acceleration_mm_s=None)`: move the motor up by supplying the following parameters:
+  - `distance_mm`: the distance in mm to move up
+  - `speed_mm_s`: the speed in mm/s to move up
+  - `acceleration_mm_s`: the acceleration in mm/s^2 to move up (optional, leave empty for default acceleration)
+- `self.sleep(seconds)`: wait for a number of seconds
+
+For example, to move the motor down by 10 mm at a speed of 5 mm/s, then wait 5 seconds, and then move up by 10 mm at 2 mm/s,
+you can write the following code in the `Coder` tab:
+
+```python
+# Arm the motor
+self.enable_motor()
+
+# Move down
+self.move_down(10, 5)
+
+# Wait for 5 seconds
+self.sleep(5)
+
+# Move up
+self.move_up(10, 2)
+
+# Disarm the motor
+self.disable_motor()
+```

--- a/src/dip_coater/tui.py
+++ b/src/dip_coater/tui.py
@@ -19,6 +19,7 @@ from textual.widgets import Header
 from textual.widgets import Label
 from textual.widgets import Input
 from textual.widgets import MarkdownViewer
+from textual.widgets import Markdown
 from textual.widgets import RadioButton
 from textual.widgets import RadioSet
 from textual.widgets import RichLog
@@ -26,6 +27,7 @@ from textual.widgets import Static
 from textual.widgets import TabPane
 from textual.widgets import TabbedContent
 from textual.widgets import TextArea
+from textual.widgets import Collapsible
 from textual.validation import Number
 
 import argparse
@@ -454,6 +456,15 @@ class Coder(Static):
     def compose(self) -> ComposeResult:
         with Vertical():
             yield Label("Enter your Coder API code below and press 'RUN code' to execute it.")
+            with Collapsible(title="View Coder API", collapsed=True, id="coder-api-collapsible"):
+                with open(Path(__file__).parent / "coder_API.md") as text:
+                    md = Markdown(
+                        text.read(),
+                        id="coder-api-markdown",
+                    )
+                    md.code_dark_theme = "monokai"
+                    yield md
+
             yield TextArea(
                 "print(\"Hello, World!\")",
                 language="python",

--- a/src/dip_coater/tui.tcss
+++ b/src/dip_coater/tui.tcss
@@ -167,5 +167,24 @@ Coder {
         margin: 0;
         padding: 0;
     }
+
+    #file-path-import-container {
+        height: 3;
+        width: 100%;
+    }
+
+    #code-file-path-input {
+        content-align: left top;
+        margin-left: 1;
+        padding: 0;
+    }
+
+    #code-file-path-input.-valid {
+        border: solid green;
+    }
+
+    #code-file-path-input.-invalid {
+        border: solid red;
+    }
 }
 

--- a/src/dip_coater/tui.tcss
+++ b/src/dip_coater/tui.tcss
@@ -154,3 +154,18 @@ AdvancedSettings {
         border: none;
     }
 }
+
+Coder {
+    #coder-api-markdown {
+        border: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    #coder-api-markdown > MarkdownFence {
+        border: none;
+        margin: 0;
+        padding: 0;
+    }
+}
+


### PR DESCRIPTION
This PR adds my personal favorite features of dip-coater: a coder window for running custom control routines using the Coder API. Here is a short demo:

https://github.com/IvS-KULeuven/dip_coater/assets/11031519/6fe64b0d-f5fd-4340-b122-830d6b3480c2

After pressing the RUN button, you are taken to the Main tab so you can follow the progress of your script in the log window.

The coder is initialized with a standard dip coating routine, where you can easily alter the up/down speed and distance and the wait time.

The available API function calls are accessible through a docstring in the coder init code + trough the help menu.